### PR TITLE
Support GET query strings from a Map of parameters

### DIFF
--- a/featherbed-core/src/main/scala/featherbed/Client.scala
+++ b/featherbed-core/src/main/scala/featherbed/Client.scala
@@ -15,6 +15,11 @@ class Client private[featherbed] (private[featherbed] val backend: ClientBackend
     Client.hostAndPort(backend.baseUrl),
     requestBuilder(relativePath))
 
+  def get(relativePath : String, params:Map[String, String]) = GetRequest[Coproduct.`"*/*"`.T](
+    this,
+    Client.hostAndPort(backend.baseUrl),
+    requestBuilder(relativePath, params))
+
   def post(relativePath : String) = PostRequest[Nothing, Nothing, None.type, Coproduct.`"*/*"`.T](
     this,
     Client.hostAndPort(backend.baseUrl),
@@ -36,6 +41,13 @@ class Client private[featherbed] (private[featherbed] val backend: ClientBackend
 
   private def requestBuilder(relativePath: String) =
     RequestBuilder().url(new URL(backend.baseUrl, relativePath))
+
+  private def queryString(params:Map[String,String]) = params.map { case (k, v) => 
+    k + "=" + v
+  }.mkString("?", "&", "")
+
+  private def requestBuilder(relativePath: String, params:Map[String,String]) = 
+    RequestBuilder().url(new URL(backend.baseUrl, relativePath + queryString(params)))
 
   protected def clientTransform(client: Http.Client): Http.Client = client
 

--- a/featherbed-core/src/main/scala/featherbed/Client.scala
+++ b/featherbed-core/src/main/scala/featherbed/Client.scala
@@ -4,7 +4,7 @@ import java.net.URL
 import com.twitter.finagle._, http.RequestBuilder
 import shapeless.Coproduct
 
-
+case class Dest(baseUrl:URL, relativePath:String)
 class Client private[featherbed] (private[featherbed] val backend: ClientBackend) {
 
   def this(baseUrl : URL) = this(ClientBackend(
@@ -12,42 +12,30 @@ class Client private[featherbed] (private[featherbed] val backend: ClientBackend
 
   def get(relativePath : String) = GetRequest[Coproduct.`"*/*"`.T](
     this,
-    Client.hostAndPort(backend.baseUrl),
+    Dest(backend.baseUrl, relativePath),
     requestBuilder(relativePath))
-
-  def get(relativePath : String, params:Map[String, String]) = GetRequest[Coproduct.`"*/*"`.T](
-    this,
-    Client.hostAndPort(backend.baseUrl),
-    requestBuilder(relativePath, params))
 
   def post(relativePath : String) = PostRequest[Nothing, Nothing, None.type, Coproduct.`"*/*"`.T](
     this,
-    Client.hostAndPort(backend.baseUrl),
+    Dest(backend.baseUrl, relativePath),
     requestBuilder(relativePath),
     None)
 
   def put(relativePath : String) = PutRequest[Nothing, Nothing, None.type, Coproduct.`"*/*"`.T](
     this,
-    Client.hostAndPort(backend.baseUrl),
+    Dest(backend.baseUrl, relativePath),
     requestBuilder(relativePath),
     multipart = false,
     None)
 
   def head(relativePath : String) =
-    HeadRequest(this, Client.hostAndPort(backend.baseUrl), requestBuilder(relativePath))
+    HeadRequest(this, Dest(backend.baseUrl, relativePath), requestBuilder(relativePath))
 
   def delete(relativePath : String) =
-    DeleteRequest[Coproduct.`"*/*"`.T](this, Client.hostAndPort(backend.baseUrl), requestBuilder(relativePath))
+    DeleteRequest[Coproduct.`"*/*"`.T](this, Dest(backend.baseUrl, relativePath), requestBuilder(relativePath))
 
-  private def requestBuilder(relativePath: String) =
+  private def requestBuilder(relativePath: String) = 
     RequestBuilder().url(new URL(backend.baseUrl, relativePath))
-
-  private def queryString(params:Map[String,String]) = params.map { case (k, v) => 
-    k + "=" + v
-  }.mkString("?", "&", "")
-
-  private def requestBuilder(relativePath: String, params:Map[String,String]) = 
-    RequestBuilder().url(new URL(backend.baseUrl, relativePath + queryString(params)))
 
   protected def clientTransform(client: Http.Client): Http.Client = client
 


### PR DESCRIPTION
Now, in addition to `client.get("posts")`, you can also do:

```scala
val queryparameters = Map(
   "param1" -> "value1",
   "param2" -> "value2"
)

client.get("posts", queryparameters)
```

This will make a get request to `http://baseurl.com/posts?param1=value1&param2=value2`.