### PR TITLE
Adds cross-build for Scala 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,8 @@ name := "featherbed"
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
   version := "0.1.0-SNAPSHOT",
-  scalaVersion := "2.11.8"
+  scalaVersion := "2.11.8",
+  crossScalaVersions := Seq("2.11.8", "2.10.6")
 )
 
 val finagleVersion = "6.34.0"
@@ -16,7 +17,10 @@ lazy val baseSettings = Seq(
     "com.chuusai" %% "shapeless" % shapelessVersion,
     "org.typelevel" %% "cats" % catsVersion,
     "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+    "org.scalatest" %% "scalatest" % "2.2.6" % "test",
+    "org.typelevel" %% "macro-compat" % "1.1.1",
+    "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+    compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
   ),
   resolvers += Resolver.sonatypeRepo("snapshots")
 )

--- a/featherbed-core/src/main/scala/featherbed/Client.scala
+++ b/featherbed-core/src/main/scala/featherbed/Client.scala
@@ -59,13 +59,13 @@ class Client private[featherbed] (private[featherbed] val backend: ClientBackend
     * @return A [[PutRequest]] object, which can further specify and send the request
     */
   def put(relativePath : String) = PutRequest[Nothing, Nothing, None.type, Coproduct.`"*/*"`.T](
-    this,
-    backend.baseUrl,
-    relativePath,
-    Map.empty,
-    RequestBuilder(),
+    client = this,
+    url = backend.baseUrl,
+    path = relativePath,
+    params = Map.empty,
+    rb = RequestBuilder(),
     multipart = false,
-    None)
+    content = None)
 
   /**
     * Specify a HEAD request to be performed against the given resource

--- a/featherbed-core/src/main/scala/featherbed/littlemacros/CoproductMacros.scala
+++ b/featherbed-core/src/main/scala/featherbed/littlemacros/CoproductMacros.scala
@@ -1,15 +1,20 @@
 package featherbed.littlemacros
 
+import macrocompat.bundle
 import shapeless.{:+:, CNil}
 
 import scala.reflect.macros.whitebox
 
-
+@bundle
 class CoproductMacros(val c: whitebox.Context) {
   import c.universe._
 
   /**
     * Support the syntax `accept("foo/bar", "foz/baz"...)`
+    *
+    * This is done instead of using [[shapeless.SingletonProductArgs]] because the latter disrupts type inference in
+    * most IDEs (besides ensime)
+    *
     * @param types Content types
     * @return Passes through to accept[ContentTypes]
     */


### PR DESCRIPTION
Requires new dependencies:
- macro-compat
- scala-compiler

These might be kind of heavy to support one macro.