### PR TITLE
Use HttpClient#newService

### DIFF
--- a/featherbed-core/src/main/scala/featherbed/Client.scala
+++ b/featherbed-core/src/main/scala/featherbed/Client.scala
@@ -74,7 +74,7 @@ class Client(
 
   protected val client = clientTransform(Client.forUrl(baseUrl))
 
-  protected[featherbed] def httpClient = client.newClient(Client.hostAndPort(baseUrl))
+  protected[featherbed] def httpClient = client.newService(Client.hostAndPort(baseUrl))
 }
 
 object Client {

--- a/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
+++ b/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
@@ -79,10 +79,7 @@ trait RequestTypes { self: Client =>
       decodeAll: DecodeAll[K, Accept]
     ): Future[Validated[InvalidResponse, K]] =
       buildRequest match {
-        case Valid(req) => for {
-          conn <- httpClient()
-          rep <- conn(req)
-        } yield {
+        case Valid(req) => httpClient(req).map { rep =>
           rep.contentType flatMap ContentTypeSupport.contentTypePieces match {
             case None => Invalid(InvalidResponse(rep, "Content-Type header is not present"))
             case Some(RuntimeContentType(mediaType, _)) =>


### PR DESCRIPTION
I did this because `HttpClient#newClient` is intended only for low-level use, and it does not ensure that clients are closed after use.  The `newService` method is the appropriate thing to use.