### PR TITLE
Error Handling

### DIFF
--- a/featherbed-core/build.sbt
+++ b/featherbed-core/build.sbt
@@ -1,1 +1,9 @@
 name := "featherbed-core"
+
+//featherbed-circe is duplicated in featherbed-core for testing
+val circeVersion = "0.5.0-M1"
+libraryDependencies ++= Seq(
+  "io.circe" %% "circe-core" % circeVersion % "test",
+  "io.circe" %% "circe-generic" % circeVersion % "test",
+  "io.circe" %% "circe-parser" % circeVersion % "test"
+)

--- a/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
+++ b/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
@@ -75,7 +75,7 @@ trait RequestTypes { self: Client =>
       out.uri = in.uri
       out.content = in.content
       in.headerMap.foreach {
-        case (k,v) => out.headerMap.put(k,v)
+        case (k, v) => out.headerMap.put(k, v)
       }
       out
     }

--- a/featherbed-core/src/main/scala/featherbed/support/package.scala
+++ b/featherbed-core/src/main/scala/featherbed/support/package.scala
@@ -11,7 +11,7 @@ package object support {
 
   @implicitNotFound("""In order to decode a request to ${A}, it must be known that a decoder exists to ${A} from
 all the content types that you Accept, which is currently ${ContentTypes}.
-You may have forgotten to specify Accept types with the `accept[T <: Coproduct]` method,
+You may have forgotten to specify Accept types with the `accept(..)` method,
 or you may be missing Decoder instances for some content types.
 """)
   sealed trait DecodeAll[A, ContentTypes <: Coproduct] {

--- a/featherbed-core/src/test/scala/featherbed/ClientSpec.scala
+++ b/featherbed-core/src/test/scala/featherbed/ClientSpec.scala
@@ -10,7 +10,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.{BeforeAndAfterEach, FlatSpec}
 import shapeless.{CNil, Coproduct, Witness}
 
-class ClientSpec extends FlatSpec with MockFactory with ClientTest with BeforeAndAfterEach {
+class ClientSpec extends FlatSpec with MockFactory with ClientTest {
 
   val receiver = stubFunction[Request, Unit]("receiveRequest")
 
@@ -27,9 +27,9 @@ class ClientSpec extends FlatSpec with MockFactory with ClientTest with BeforeAn
 
     val req = client.get("foo/bar").accept("text/plain")
 
-    Await.result(for {
+    intercept[Throwable](Await.result(for {
       rep <- req.send[String]()
-    } yield ())
+    } yield ()))
 
     receiver verify request { req =>
       assert(req.uri == "/api/v1/foo/bar")
@@ -45,9 +45,9 @@ class ClientSpec extends FlatSpec with MockFactory with ClientTest with BeforeAn
       .withQueryParams("param" -> "value")
       .accept("text/plain")
 
-    Await.result(for {
+    intercept[Throwable](Await.result(for {
       rep <- req.send[String]()
-    } yield ())
+    } yield ()))
 
     receiver verify request { req =>
       assert(req.uri == "/api/v1/foo/bar?param=value")
@@ -62,9 +62,9 @@ class ClientSpec extends FlatSpec with MockFactory with ClientTest with BeforeAn
       .withContent("Hello world", "text/plain")
       .accept("text/plain")
 
-    Await.result(for {
+    intercept[Throwable](Await.result(for {
       rep <- req.send[String]()
-    } yield ())
+    } yield ()))
 
     receiver verify request { req =>
       assert(req.uri == "/api/v1/foo/bar")
@@ -81,7 +81,7 @@ class ClientSpec extends FlatSpec with MockFactory with ClientTest with BeforeAn
       .withParams("foo" -> "bar", "bar" -> "baz")
       .accept("text/plain")
 
-    Await.result(req.send[String]())
+    intercept[Throwable](Await.result(req.send[String]()))
 
     receiver verify request { req =>
       assert(req.uri == "/api/v1/foo/bar")
@@ -96,7 +96,7 @@ class ClientSpec extends FlatSpec with MockFactory with ClientTest with BeforeAn
     val req = client
       .head("foo/bar")
 
-    Await.result(req.send[Response]())
+    intercept[Throwable](Await.result(req.send[Response]()))
 
     receiver verify request { req =>
       assert(req.uri == "/api/v1/foo/bar")
@@ -109,7 +109,7 @@ class ClientSpec extends FlatSpec with MockFactory with ClientTest with BeforeAn
       .delete("foo/bar")
       .accept("text/plain")
 
-    Await.result(req.send[String]())
+    intercept[Throwable](Await.result(req.send[String]()))
 
     receiver verify request { req =>
       assert(req.uri == "/api/v1/foo/bar")
@@ -123,7 +123,7 @@ class ClientSpec extends FlatSpec with MockFactory with ClientTest with BeforeAn
       .withContent("Hello world", "text/plain")
       .accept("text/plain")
 
-    Await.result(req.send[String]())
+    intercept[Throwable](Await.result(req.send[String]()))
 
     receiver verify request { req =>
       assert(req.uri == "/api/v1/foo/bar")

--- a/featherbed-core/src/test/scala/featherbed/ErrorHandlingSpec.scala
+++ b/featherbed-core/src/test/scala/featherbed/ErrorHandlingSpec.scala
@@ -1,0 +1,219 @@
+package featherbed
+
+import java.nio.charset.Charset
+
+import featherbed.circe._
+import featherbed.content.Encoder
+
+import cats.data.{NonEmptyList, Xor}
+import cats.data.Validated.{Invalid, Valid}
+import com.twitter.finagle.{Service, SimpleFilter}
+import com.twitter.finagle.http.{Request, Response}
+import com.twitter.io.Buf
+import com.twitter.util.{Await, Future}
+import featherbed.request.{ErrorResponse, InvalidResponse, RequestBuildingError}
+import io.circe.generic.auto._
+import io.circe.syntax._
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.FreeSpec
+import shapeless.Witness
+
+class ErrorHandlingSpec extends FreeSpec with MockFactory with ClientTest {
+
+  case class TestResponse(foo: String, bar: Int)
+  case class TestError(baz: String, buzz: Boolean)
+
+  val testResponse = TestResponse("foo", 22)
+  val testError = TestError("baz", true)
+
+  sealed trait TestContent
+  case object GoodContent extends TestContent
+  case object BadContent extends TestContent
+
+  implicit val testContentEncoder: Encoder[TestContent, Witness.`"test/content"`.T] = Encoder.of("test/content") {
+      case (GoodContent, _) => Valid(Buf.Utf8("Good")).toValidatedNel
+      case (BadContent, _) => Invalid(NonEmptyList(new Exception("Bad")))
+    }
+
+
+  val receiver = mockFunction[Request, Response]("receiveRequest")
+
+  object InterceptRequest extends SimpleFilter[Request, Response] {
+    override def apply(request: Request, service: Service[Request, Response]): Future[Response] = {
+      Future(receiver(request))
+    }
+  }
+
+  val client = mockClient("http://example.com/api/v1/", InterceptRequest)
+
+  "send[K]" - {
+
+    "returns failed future when request is invalid" in {
+      val content: TestContent = BadContent
+      val req = client.post("foo")
+        .withContent(content, "test/content")
+        .accept("application/json")
+
+      intercept[RequestBuildingError](Await.result(req.send[TestResponse]()))
+    }
+
+    "returns failed future when request fails" - {
+      (400 to 404) ++ (500 to 503) foreach { code =>
+        code.toString in {
+          receiver expects * returning {
+            val response = Response()
+            response.statusCode = code
+            response
+          }
+          val content: TestContent = GoodContent
+          val req = client.post("foo")
+            .withContent(content, "test/content")
+            .accept("application/json")
+
+          intercept[ErrorResponse](Await.result(req.send[TestResponse]()))
+        }
+      }
+    }
+
+    "returns failed future when response has unacceptable content type" in {
+      receiver expects * returning {
+        val response = Response()
+        response.statusCode = 200
+        response.contentType = "foo/bar"
+        response.contentString = testResponse.asJson.noSpaces
+        response
+      }
+      val content: TestContent = GoodContent
+      val req = client.post("foo")
+        .withContent(content, "test/content")
+        .accept("application/json")
+      intercept[InvalidResponse](Await.result(req.send[TestResponse]()))
+    }
+
+    "returns failed future when response fails to decode" in {
+      receiver expects * returning {
+        val response = Response()
+        response.statusCode = 200
+        response.contentType = "application/json"
+        response.contentString = "not json"
+        response
+      }
+      val content: TestContent = GoodContent
+      val req = client.post("foo")
+        .withContent(content, "test/content")
+        .accept("application/json")
+      intercept[InvalidResponse](Await.result(req.send[TestResponse]()))
+    }
+
+    "returns successful future when everything works" in {
+      receiver expects * returning {
+        val response = Response()
+        response.statusCode = 200
+        response.contentType = "application/json"
+        response.contentString = testResponse.asJson.noSpaces
+        response
+      }
+      val content: TestContent = GoodContent
+      val req = client.post("foo")
+        .withContent(content, "test/content")
+        .accept("application/json")
+      val result = Await.result(req.send[TestResponse]())
+      assert(result == testResponse)
+    }
+
+  }
+
+  "send[Error, Success]" - {
+
+    "returns failed future when request is invalid" in {
+      val content: TestContent = BadContent
+      val req = client.post("foo")
+        .withContent(content, "test/content")
+        .accept("application/json")
+
+      intercept[RequestBuildingError](Await.result(req.send[TestError, TestResponse]()))
+    }
+
+    "returns successful future when request fails with valid error response" - {
+      (400 to 404) ++ (500 to 503) foreach { code =>
+        code.toString in {
+          receiver expects * returning {
+            val response = Response()
+            response.statusCode = code
+            response.contentType = "application/json"
+            response.contentString = testError.asJson.noSpaces
+            response
+          }
+          val content: TestContent = GoodContent
+          val req = client.post("foo")
+            .withContent(content, "test/content")
+            .accept("application/json")
+
+          val result = Await.result(req.send[TestError, TestResponse]())
+          assert(result == Xor.Left(testError))
+        }
+      }
+    }
+
+    "returns failed future when response has unacceptable content type" in {
+      receiver expects * returning {
+        val response = Response()
+        response.statusCode = 200
+        response.contentType = "foo/bar"
+        response.contentString = testResponse.asJson.noSpaces
+        response
+      }
+      val content: TestContent = GoodContent
+      val req = client.post("foo")
+        .withContent(content, "test/content")
+        .accept("application/json")
+      intercept[InvalidResponse](Await.result(req.send[TestError, TestResponse]()))
+    }
+
+    "returns failed future when successful response fails to decode" in {
+      receiver expects * returning {
+        val response = Response()
+        response.statusCode = 200
+        response.contentType = "application/json"
+        response.contentString = "not json"
+        response
+      }
+      val content: TestContent = GoodContent
+      val req = client.post("foo")
+        .withContent(content, "test/content")
+        .accept("application/json")
+      intercept[InvalidResponse](Await.result(req.send[TestError, TestResponse]()))
+    }
+
+    "returns failed future when error response fails to decode" in {
+      receiver expects * returning {
+        val response = Response()
+        response.statusCode = 400
+        response.contentType = "applicatoin/json"
+        response.contentString = "not json"
+        response
+      }
+      val content: TestContent = GoodContent
+      val req = client.post("foo")
+        .withContent(content, "test/content")
+        .accept("application/json")
+      intercept[InvalidResponse](Await.result(req.send[TestError, TestResponse]()))
+    }
+
+    "returns successful future when everything works" in {
+      receiver expects * returning {
+        val response = Response()
+        response.statusCode = 200
+        response.contentType = "application/json"
+        response.contentString = testResponse.asJson.noSpaces
+        response
+      }
+      val content: TestContent = GoodContent
+      val req = client.post("foo")
+        .withContent(content, "test/content")
+        .accept("application/json")
+      val result = Await.result(req.send[TestError, TestResponse]())
+      assert(result == Xor.Right(testResponse))
+    }
+  }
+}

--- a/featherbed-core/src/test/scala/featherbed/circe/package.scala
+++ b/featherbed-core/src/test/scala/featherbed/circe/package.scala
@@ -1,0 +1,31 @@
+package featherbed
+
+import java.nio.charset.Charset
+
+import cats.data.ValidatedNel
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.parser._
+import io.circe.syntax._
+import shapeless.Witness
+
+package object circe {
+
+  private val printer = Printer.noSpaces.copy(dropNullKeys = true)
+
+  implicit def circeEncoder[A: Encoder]: content.Encoder[A, Witness.`"application/json"`.T] =
+    content.Encoder.of("application/json") {
+      (value: A, charset: Charset) => content.Encoder.encodeString(printer.pretty(value.asJson), charset)
+    }
+
+  implicit def circeDecoder[A: Decoder]: content.Decoder.Aux[Witness.`"application/json"`.T, A] =
+    content.Decoder.of("application/json") {
+      response =>
+        content.Decoder.decodeString(response).andThen {
+          str => (parse(str).toValidated.toValidatedNel: ValidatedNel[Throwable, Json]).andThen {
+            json: Json => json.as[A].toValidated.toValidatedNel: ValidatedNel[Throwable, A]
+          }
+        }
+    }
+
+}


### PR DESCRIPTION
This commit adds error handling to featherbed.

API Changes:
1. A new method `send[Error, Success]` is introduced. It allows for handling error responses (>= 400) using a separate ADT `Error`. The result is `Future[Xor[Error, Success]]`. Both `Error` and `Success` cases must still be able to be `Decoded` using all `Accept`ed content types.
2. The method `send[K]` now returns `Future[K]` instead of `Future[Validated[InvalidResponse, K]]`, and the error case is encoded in the `Future` itself.  This method will also now handle HTTP errors from the remote HTTP server, but they will be encoded as failed futures (in contrast to `Send[Error, Success]`).
3. featherbed now follows redirects (301, 302, 303, and 307) up to 5 levels.  This number could potentially be configurable at some point.