### PR TITLE
Avoid creating more than one service client

### DIFF
--- a/featherbed-core/src/main/scala/featherbed/Client.scala
+++ b/featherbed-core/src/main/scala/featherbed/Client.scala
@@ -74,7 +74,7 @@ class Client(
 
   protected val client = clientTransform(Client.forUrl(baseUrl))
 
-  protected[featherbed] def httpClient = client.newService(Client.hostAndPort(baseUrl))
+  protected[featherbed] val httpClient = client.newService(Client.hostAndPort(baseUrl))
 }
 
 object Client {


### PR DESCRIPTION
This avoids the situation where lots of clients use up the system socket handles.