### PR TITLE
Added sendZip method to return both the decoded response, and the fin…

### DIFF
--- a/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
+++ b/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
@@ -190,7 +190,8 @@ trait RequestTypes { self: Client =>
       canBuild: CanBuildRequest[Self],
       decodeAllSuccess: DecodeAll[Success, Accept],
       decodeAllError: DecodeAll[Error, Accept]
-    ): Future[Xor[Error, Success]] = sendZipRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError).map(_._1)
+    ): Future[Xor[Error, Success]] =
+      sendZipRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError).map(_._1)
 
   }
 

--- a/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
+++ b/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
@@ -172,19 +172,25 @@ trait RequestTypes { self: Client =>
         case Invalid(errs) => Future.exception(RequestBuildingError(errs))
       }
 
+    protected def sendZipRequest[Error, Success](implicit
+      canBuild: CanBuildRequest[Self],
+      decodeAllSuccess: DecodeAll[Success, Accept],
+      decodeAllError: DecodeAll[Error, Accept]
+    ): Future[(Xor[Error, Success], Response)] = buildRequest match {
+      case Valid(req) => handleRequest(req)
+        .flatMap {
+          rep => decodeResponse[Success](rep).map(Xor.right[Error, Success]).map((_, rep))
+        }.rescue {
+          case ErrorResponse(_, rep) => decodeResponse[Error](rep).map(Xor.left[Error, Success]).map((_, rep))
+        }
+      case Invalid(errs) => Future.exception(RequestBuildingError(errs))
+    }
+
     protected def sendRequest[Error, Success](implicit
       canBuild: CanBuildRequest[Self],
       decodeAllSuccess: DecodeAll[Success, Accept],
       decodeAllError: DecodeAll[Error, Accept]
-    ): Future[Xor[Error, Success]] = buildRequest match {
-      case Valid(req) => handleRequest(req)
-        .flatMap {
-          rep => decodeResponse[Success](rep).map(Xor.right[Error, Success])
-        }.rescue {
-          case ErrorResponse(_, rep) => decodeResponse[Error](rep).map(Xor.left[Error, Success])
-        }
-      case Invalid(errs) => Future.exception(RequestBuildingError(errs))
-    }
+    ): Future[Xor[Error, Success]] = sendZipRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError).map(_._1)
 
   }
 
@@ -210,7 +216,15 @@ trait RequestTypes { self: Client =>
       canBuild: CanBuildRequest[GetRequest[Accept]],
       decodeAllError: DecodeAll[Error, Accept],
       decodeAllSuccess: DecodeAll[Success, Accept]
-    ): Future[Xor[Error, Success]] = sendRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
+    ): Future[Xor[Error, Success]] =
+      sendRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
+
+    def sendZip[Error, Success]()(implicit
+      canBuild: CanBuildRequest[GetRequest[Accept]],
+      decodeAllError: DecodeAll[Error, Accept],
+      decodeAllSuccess: DecodeAll[Success, Accept]
+    ): Future[(Xor[Error, Success], Response)] =
+      sendZipRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
   }
 
   case class PostRequest[Content, ContentType, Accept <: Coproduct] (
@@ -291,6 +305,13 @@ trait RequestTypes { self: Client =>
       decodeAllError: DecodeAll[Error, Accept],
       decodeAllSuccess: DecodeAll[Success, Accept]
     ): Future[Xor[Error, Success]] = sendRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
+
+    def sendZip[Error, Success]()(implicit
+      canBuild: CanBuildRequest[PostRequest[Content, ContentType, Accept]],
+      decodeAllError: DecodeAll[Error, Accept],
+      decodeAllSuccess: DecodeAll[Success, Accept]
+    ): Future[(Xor[Error, Success], Response)] =
+      sendZipRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
   }
 
   case class FormPostRequest[
@@ -372,6 +393,13 @@ trait RequestTypes { self: Client =>
       decodeAllError: DecodeAll[Error, Accept],
       decodeAllSuccess: DecodeAll[Success, Accept]
     ): Future[Xor[Error, Success]] = sendRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
+
+    def sendZip[Error, Success]()(implicit
+      canBuild: CanBuildRequest[FormPostRequest[Accept, Elements]],
+      decodeAllError: DecodeAll[Error, Accept],
+      decodeAllSuccess: DecodeAll[Success, Accept]
+    ): Future[(Xor[Error, Success], Response)] =
+      sendZipRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
   }
 
   case class PutRequest[Content, ContentType, Accept <: Coproduct](
@@ -409,6 +437,13 @@ trait RequestTypes { self: Client =>
       decodeAllError: DecodeAll[Error, Accept],
       decodeAllSuccess: DecodeAll[Success, Accept]
     ): Future[Xor[Error, Success]] = sendRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
+
+    def sendZip[Error, Success]()(implicit
+      canBuild: CanBuildRequest[PutRequest[Content, ContentType, Accept]],
+      decodeAllError: DecodeAll[Error, Accept],
+      decodeAllSuccess: DecodeAll[Success, Accept]
+    ): Future[(Xor[Error, Success], Response)] =
+      sendZipRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
   }
 
   case class HeadRequest(
@@ -451,6 +486,13 @@ trait RequestTypes { self: Client =>
       decodeAllError: DecodeAll[Error, Accept],
       decodeAllSuccess: DecodeAll[Success, Accept]
     ): Future[Xor[Error, Success]] = sendRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
+
+    def sendZip[Error, Success]()(implicit
+      canBuild: CanBuildRequest[DeleteRequest[Accept]],
+      decodeAllError: DecodeAll[Error, Accept],
+      decodeAllSuccess: DecodeAll[Success, Accept]
+    ): Future[(Xor[Error, Success], Response)] =
+      sendZipRequest[Error, Success](canBuild, decodeAllSuccess, decodeAllError)
   }
 
 }

--- a/featherbed-core/src/test/scala/featherbed/ClientSpec.scala
+++ b/featherbed-core/src/test/scala/featherbed/ClientSpec.scala
@@ -133,6 +133,105 @@ class ClientSpec extends FlatSpec with MockFactory with ClientTest {
     }
   }
 
+  ///---
+  it should "sendZip: get" in {
+
+    val req = client.get("foo/bar").accept("text/plain")
+
+    intercept[Throwable](Await.result(for {
+      rep <- req.sendZip[String, String]()
+    } yield ()))
+
+    receiver verify request { req =>
+      assert(req.uri == "/api/v1/foo/bar")
+      assert(req.method == Method.Get)
+      assert((req.accept.toSet diff Set("text/plain", "*/*; q=0")) == Set.empty)
+    }
+  }
+
+  it should "sendZip: get with query params" in {
+
+    val req = client
+      .get("foo/bar")
+      .withQueryParams("param" -> "value")
+      .accept("text/plain")
+
+    intercept[Throwable](Await.result(for {
+      rep <- req.sendZip[String, String]()
+    } yield ()))
+
+    receiver verify request { req =>
+      assert(req.uri == "/api/v1/foo/bar?param=value")
+      assert(req.method == Method.Get)
+      assert((req.accept.toSet diff Set("text/plain", "*/*; q=0")) == Set.empty)
+    }
+  }
+
+  it should "sendZip: post" in {
+    val req = client
+      .post("foo/bar")
+      .withContent("Hello world", "text/plain")
+      .accept("text/plain")
+
+    intercept[Throwable](Await.result(for {
+      rep <- req.sendZip[String, String]()
+    } yield ()))
+
+    receiver verify request { req =>
+      assert(req.uri == "/api/v1/foo/bar")
+      assert(req.method == Method.Post)
+      assert(req.headerMap("Content-Type") == s"text/plain; charset=${Charset.defaultCharset.name}")
+      assert(req.contentString == "Hello world")
+      assert((req.accept.toSet diff Set("text/plain", "*/*; q=0")) == Set.empty)
+    }
+  }
+
+  it should "sendZip: post a form" in {
+    val req = client
+      .post("foo/bar")
+      .withParams("foo" -> "bar", "bar" -> "baz")
+      .accept("text/plain")
+
+    intercept[Throwable](Await.result(req.sendZip[String, String]()))
+
+    receiver verify request { req =>
+      assert(req.uri == "/api/v1/foo/bar")
+      assert(req.method == Method.Post)
+      assert(req.headerMap("Content-Type") == s"application/x-www-form-urlencoded")
+      assert(req.contentString == "foo=bar&bar=baz")
+      assert((req.accept.toSet diff Set("text/plain", "*/*; q=0")) == Set.empty)
+    }
+  }
+
+  it should "sendZip: delete" in {
+    val req = client
+      .delete("foo/bar")
+      .accept("text/plain")
+
+    intercept[Throwable](Await.result(req.sendZip[String, String]()))
+
+    receiver verify request { req =>
+      assert(req.uri == "/api/v1/foo/bar")
+      assert(req.method == Method.Delete)
+    }
+  }
+
+  it should "sendZip: put" in {
+    val req = client
+      .put("foo/bar")
+      .withContent("Hello world", "text/plain")
+      .accept("text/plain")
+
+    intercept[Throwable](Await.result(req.sendZip[String, String]()))
+
+    receiver verify request { req =>
+      assert(req.uri == "/api/v1/foo/bar")
+      assert(req.method == Method.Put)
+      assert(req.contentType.contains(s"text/plain; charset=${Charset.defaultCharset.name}"))
+      assert(req.contentString == "Hello world")
+    }
+  }
+
   "Compile" should "fail when no encoder is available for the request" in {
     assertDoesNotCompile(
       """


### PR DESCRIPTION
This adds a `sendZip[Error, Success]` method that behaves just like `send[Error, Success]`, except that it returns a `(Xor[Error, Success], Response)` to allow access to the finagle response object for the purpose of obtaining headers, and any other necessary information.

I'm not the biggest fan of the method name, but it's what was thrown out as a possibility in gitter.