### PR TITLE
Added serviceTransform

### DIFF
--- a/featherbed-core/src/main/scala/featherbed/Client.scala
+++ b/featherbed-core/src/main/scala/featherbed/Client.scala
@@ -78,9 +78,11 @@ class Client(
 
   protected def clientTransform(client: Http.Client): Http.Client = client
 
+  protected def serviceTransform[Req, Rep](service: Service[Req, Rep]): Service[Req, Rep] = service
+
   protected val client = clientTransform(Client.forUrl(baseUrl))
 
-  protected[featherbed] val httpClient = client.newService(Client.hostAndPort(baseUrl))
+  protected[featherbed] val httpClient = serviceTransform(client.newService(Client.hostAndPort(baseUrl)))
 }
 
 object Client {


### PR DESCRIPTION
In the same manner that we allow overrides on clients, added a `serviceTransform` so that we can add filters, etc. to services.

Our use case is that we want to be able to apply filters to the returned `Service`.