### PR TITLE
Scala 2.12 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target
 doc
 .ensime
 .ensime_cache/*
+sbt

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ jdk:
 script:
   - sbt ++$TRAVIS_SCALA_VERSION validate
   - sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
-  - sbt + package
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 sudo: false
 language: scala
 scala:
-   - 2.11.8
+   - 2.12.1
 jdk:
    - oraclejdk8
 
 script:
   - sbt ++$TRAVIS_SCALA_VERSION validate
   - sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+  - sbt + package
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: scala
 scala:
+   - 2.11.8
    - 2.12.1
 jdk:
    - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: scala
 scala:
-   - 2.11.8
-   - 2.12.1
+   - 2.11.11
+   - 2.12.2
 jdk:
    - oraclejdk8
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
 
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
-  version := "0.2.1-SNAPSHOT",
+  version := "0.2.1-9641342",
   scalaVersion := "2.12.1",
   crossScalaVersions := Seq("2.11.8", "2.12.1")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
 
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
-  version := "0.2.1-9641342",
+  version := "0.2.1-SNAPSHOT",
   scalaVersion := "2.12.1",
   crossScalaVersions := Seq("2.11.8", "2.12.1")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val buildSettings = Seq(
   crossScalaVersions := Seq("2.11.8", "2.12.1")
 )
 
-val finagleVersion = "6.41.0"
+val finagleVersion = "6.42.0"
 val shapelessVersion = "2.3.2"
 val catsVersion = "0.9.0"
 
@@ -23,7 +23,7 @@ lazy val baseSettings = docSettings ++ Seq(
     "com.twitter" %% "finagle-http" % finagleVersion,
     "com.chuusai" %% "shapeless" % shapelessVersion,
     "org.typelevel" %% "cats" % catsVersion,
-    "org.scalamock" %% "scalamock-scalatest-support" % "3.4.2" % "test",
+    "org.scalamock" %% "scalamock-scalatest-support" % "3.5.0" % "test",
     "org.scalatest" %% "scalatest" % "3.0.1" % "test"
   ),
   resolvers += Resolver.sonatypeRepo("snapshots")

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,8 @@ import com.typesafe.sbt.SbtGhPages.GhPagesKeys._
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
   version := "0.2.1-SNAPSHOT",
-  scalaVersion := "2.11.8"
+  scalaVersion := "2.12.1",
+  crossScalaVersions := Seq("2.11.8", "2.12.1")
 )
 
 val finagleVersion = "6.41.0"
@@ -22,8 +23,8 @@ lazy val baseSettings = docSettings ++ Seq(
     "com.twitter" %% "finagle-http" % finagleVersion,
     "com.chuusai" %% "shapeless" % shapelessVersion,
     "org.typelevel" %% "cats" % catsVersion,
-    "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test",
-    "org.scalatest" %% "scalatest" % "2.2.6" % "test"
+    "org.scalamock" %% "scalamock-scalatest-support" % "3.4.2" % "test",
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
   ),
   resolvers += Resolver.sonatypeRepo("snapshots")
 )

--- a/featherbed-circe/build.sbt
+++ b/featherbed-circe/build.sbt
@@ -1,6 +1,6 @@
 name := "featherbed-circe"
 
-val circeVersion = "0.7.0"
+val circeVersion = "0.7.1"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,

--- a/featherbed-core/build.sbt
+++ b/featherbed-core/build.sbt
@@ -1,7 +1,7 @@
 name := "featherbed-core"
 
 //featherbed-circe is duplicated in featherbed-core for testing
-val circeVersion = "0.7.0"
+val circeVersion = "0.7.1"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion % "test",

--- a/featherbed-core/src/main/scala/featherbed/Client.scala
+++ b/featherbed-core/src/main/scala/featherbed/Client.scala
@@ -78,9 +78,11 @@ class Client(
 
   protected def clientTransform(client: Http.Client): Http.Client = client
 
+  protected def serviceTransform[Req, Rep](service: Service[Req, Rep]): Service[Req, Rep] = service
+
   protected val client = clientTransform(Client.forUrl(baseUrl))
 
-  protected[featherbed] val httpClient = client.newService(Client.hostAndPort(baseUrl))
+  protected[featherbed] val httpClient = serviceTransform(client.newService(Client.hostAndPort(baseUrl)))
 }
 
 object Client {

--- a/featherbed-core/src/main/scala/featherbed/Client.scala
+++ b/featherbed-core/src/main/scala/featherbed/Client.scala
@@ -5,7 +5,7 @@ import java.nio.charset.{Charset, StandardCharsets}
 
 import com.twitter.finagle._
 import com.twitter.finagle.builder.ClientBuilder
-import http.RequestBuilder
+import http.{Request, RequestBuilder, Response}
 import shapeless.Coproduct
 
 /**
@@ -78,7 +78,7 @@ class Client(
 
   protected def clientTransform(client: Http.Client): Http.Client = client
 
-  protected def serviceTransform[Req, Rep](service: Service[Req, Rep]): Service[Req, Rep] = service
+  protected def serviceTransform(service: Service[Request, Response]): Service[Request, Response] = service
 
   protected val client = clientTransform(Client.forUrl(baseUrl))
 

--- a/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
+++ b/featherbed-core/src/main/scala/featherbed/request/RequestSyntax.scala
@@ -27,8 +27,8 @@ import shapeless.{CNil, Coproduct, Witness}
   * @param response The original [[Response]], so it can be further processed if desired
   * @param reason A [[String]] describing why the response was invalid
   */
-case class InvalidResponse(response: Response, reason: String) extends Throwable
-case class ErrorResponse(request: Request, response: Response) extends Throwable
+case class InvalidResponse(response: Response, reason: String) extends Throwable(reason)
+case class ErrorResponse(request: Request, response: Response) extends Throwable("Error response received")
 
 trait RequestTypes { self: Client =>
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,9 +4,9 @@ resolvers ++= Seq(
   Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 )
 
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.8")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,14 +4,14 @@ resolvers ++= Seq(
   Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 )
 
-addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.1")
+addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.4.8")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.2.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.1.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.0")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.3")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")


### PR DESCRIPTION
Cross compilation support for 2.12 & 2.11. Also updated all the dependencies & plugins*. Also includes #52.

*Note: Updated to match the latest Finch versions, so not the entirely latest versions of Finagle & co.