### PR TITLE
make client val lazy to allow Client to be extended

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ enablePlugins(TutPlugin)
 
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
-  version := "0.3.1",
+  version := "0.3.2-SNAPSHOT",
   scalaVersion := "2.12.2",
   crossScalaVersions := Seq("2.11.11", "2.12.2")
 )

--- a/featherbed-core/src/main/scala/featherbed/Client.scala
+++ b/featherbed-core/src/main/scala/featherbed/Client.scala
@@ -80,9 +80,9 @@ class Client(
 
   protected def serviceTransform(service: Service[Request, Response]): Service[Request, Response] = service
 
-  protected val client = clientTransform(Client.forUrl(baseUrl))
+  protected lazy val client = clientTransform(Client.forUrl(baseUrl))
 
-  protected[featherbed] val httpClient = serviceTransform(client.newService(Client.hostAndPort(baseUrl)))
+  protected[featherbed] lazy val httpClient = serviceTransform(client.newService(Client.hostAndPort(baseUrl)))
 }
 
 object Client {


### PR DESCRIPTION
I recently had a use case where I needed to access a server which had self signed certificates, so I needed to change the underlying Client code in featherbed to use other finagle options.  It turns out if you make the instantiation of the val client in the class client lazy, you can do this by extending the class without modifying the Client.scala source. Without the client being lazy you get initialization errors. 

Here was my use case:

````
package featherbed 

class InsecureClient(
  baseUrl: URL,
  charset: Charset = StandardCharsets.UTF_8)
  extends Client(baseUrl, charset) {

  override protected lazy val client = clientTransform(InsecureClient.forUrl(baseUrl))
}

object InsecureClient {

  private[featherbed] def forUrl(url: URL) = {
    val client = Http.Client()
    if (url.getProtocol == "https") client.withTlsWithoutValidation else client
  }
}
````

Let me know if more needs to be done. 