### PR TITLE
Updating the circe dependency to 0.9-M2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ enablePlugins(TutPlugin)
 
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
-  version := "0.3.2-snapshot",
+  version := "0.3.2",
   scalaVersion := "2.12.2",
   crossScalaVersions := Seq("2.11.11", "2.12.2")
 )

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ enablePlugins(TutPlugin)
 
 lazy val buildSettings = Seq(
   organization := "io.github.finagle",
-  version := "0.3.1",
+  version := "0.3.2-snapshot",
   scalaVersion := "2.12.2",
   crossScalaVersions := Seq("2.11.11", "2.12.2")
 )

--- a/featherbed-circe/build.sbt
+++ b/featherbed-circe/build.sbt
@@ -1,6 +1,6 @@
 name := "featherbed-circe"
 
-val circeVersion = "0.8.0"
+val circeVersion = "0.9.0-M2"
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,

--- a/featherbed-circe/src/main/scala/featherbed/circe/package.scala
+++ b/featherbed-circe/src/main/scala/featherbed/circe/package.scala
@@ -12,7 +12,7 @@ import shapeless.Witness
 
 package object circe {
 
-  private val printer = Printer.noSpaces.copy(dropNullKeys = true)
+  private val printer = Printer.noSpaces.copy(dropNullValues = true)
 
   implicit def circeEncoder[A: Encoder]: content.Encoder[A, Witness.`"application/json"`.T] =
     content.Encoder.of("application/json") {


### PR DESCRIPTION
I have updated circe dependency to `0.9.0-M2`. This is a breaking change and so I have updated the main version to `0.3.2-snapshot` ? (I am not sure on how to go about semantic versioning)
changes seems to be minor.